### PR TITLE
Emit open event with multiple hubs

### DIFF
--- a/index.js
+++ b/index.js
@@ -36,6 +36,9 @@ module.exports = function (app, urls) {
 
     all.setMaxListeners(0)
     streams.forEach(function (stream) {
+      stream.on('open', function () {
+        all.emit('open')
+      })
       pump(stream, all)
     })
 

--- a/test.js
+++ b/test.js
@@ -43,6 +43,18 @@ server.listen(9000, function () {
     c.broadcast('hello/people', [1, 2, 3])
   })
 
+  tape('open emitted with multiple hubs', function (t) {
+    var c = client('app', [
+      'localhost:9000',
+      'localhost:9000'
+    ])
+    c.subscribe('hello').on('open', function () {
+      t.ok(true, 'got an open event')
+      this.destroy()
+      t.end()
+    })
+  })
+
   tape('end', function (t) {
     server.close()
     t.ok(true)


### PR DESCRIPTION
This bubbles the `open` event when we have multiple hubs.

It should fix https://github.com/mafintosh/webrtc-swarm/issues/1 and https://github.com/mafintosh/webrtc-swarm/issues/2

Thanks!