### PR TITLE
remove opts argument to http.createServer

### DIFF
--- a/server.js
+++ b/server.js
@@ -93,7 +93,8 @@ module.exports = function (opts) {
     res.end()
   })
 
-  var server = ((opts && opts.key) ? https : http).createServer(opts)
+  var useHttps = !!(opts && opts.key && opts.cert)
+  var server = useHttps ? https.createServer(opts) : http.createServer()
   server.on('request', onRequest)
 
   return server


### PR DESCRIPTION
`https.createServer` can take an opts parameter, but `http.createServer` cannot.