### PR TITLE
Allow non-HTTPS servers to be created

### DIFF
--- a/server.js
+++ b/server.js
@@ -93,8 +93,10 @@ module.exports = function (opts) {
     res.end()
   })
 
-  var useHttps = !!(opts && opts.key && opts.cert)
-  var server = useHttps ? https.createServer(opts) : http.createServer()
+  var server = (opts && opts.key)
+    ? https.createServer(opts)
+    : http.createServer()
+
   server.on('request', onRequest)
 
   return server


### PR DESCRIPTION
Previously, `opts` was being passed to `http.createServer`, which only accepts a request-handling function as its first argument. Creating an HTTP server would result in the following error:

    TypeError: listener must be a function

Thanks! :)