### PR TITLE
small fixes to cli program and example.js

### DIFF
--- a/bin.js
+++ b/bin.js
@@ -37,7 +37,7 @@ if (cmd === 'listen') {
     console.log('subscribe: %s', channel)
   })
 
-  server.on('broadcast', function (channel, message) {
+  server.on('publish', function (channel, message) {
     console.log('broadcast: %s (%d)', channel, message.length)
   })
 
@@ -48,8 +48,8 @@ if (cmd === 'listen') {
 }
 
 if (cmd === 'subscribe') {
-  if (argv.length < 3) return console.error('Usage: signalhub subscribe [app] [channel]')
-  var client = require('./')(argv._[1], argv.host || 'localhost')
+  if (argv._.length < 3) return console.error('Usage: signalhub subscribe [app] [channel]')
+  var client = require('./')(argv._[1], argv.host + ':' + argv.port || 'localhost:8080')
   client.subscribe(argv._[2]).on('data', function (data) {
     console.log(data)
   })
@@ -57,8 +57,8 @@ if (cmd === 'subscribe') {
 }
 
 if (cmd === 'broadcast') {
-  if (argv.length < 4) return console.error('Usage: signalhub broadcast [app] [channel] [json-message]')
-  var client = require('./')(argv._[1], argv.host || 'localhost')
+  if (argv._.length < 4) return console.error('Usage: signalhub broadcast [app] [channel] [json-message]')
+  var client = require('./')(argv._[1], argv.host + ':' + argv.port || 'localhost:8080')
   client.broadcast(argv._[2], JSON.parse(argv._[3]))
   return
 }

--- a/example.js
+++ b/example.js
@@ -2,7 +2,7 @@ var server = require('./server')
 var client = require('./')
 
 server().listen(9000, function () {
-  var c = client('localhost:9000')
+  var c = client('app', 'localhost:9000')
 
   c.subscribe('hello').on('data', console.log)
 


### PR DESCRIPTION
this might fix #11 and #6 

* use an app name when creating client
* throw error messages when argv length is incorrect
* use server.on('publish', ...) instead of broadcast
* use argv.host and argv.port in bin when broadcasting and subscribing