### PR TITLE
Quiet

### DIFF
--- a/README.md
+++ b/README.md
@@ -68,6 +68,8 @@ To listen on https, use the `--key` and `--cert` flags to specify the path to th
 key and certificate files, respectively. These will be passed through to the node `https`
 package.
 
+To avoid logging to console on every subscribe/broadcast event use the `--quiet` or `-q` flag.
+
 Or broadcast/subscribe to channels
 
 ```

--- a/bin.js
+++ b/bin.js
@@ -9,9 +9,10 @@ var argv = minimist(process.argv.slice(2), {
     'max-broadcasts': 'm',
     key: 'k',
     cert: 'c',
-    version: 'v'
+    version: 'v',
+    quiet: 'q'
   },
-  boolean: [ 'version' ],
+  boolean: [ 'version', 'quiet' ],
   default: {
     port: process.env.PORT || 80
   }
@@ -33,13 +34,15 @@ if (cmd === 'listen') {
     host: argv.host
   })
 
-  server.on('subscribe', function (channel) {
-    console.log('subscribe: %s', channel)
-  })
+  if (!argv.quiet) {
+    server.on('subscribe', function (channel) {
+      console.log('subscribe: %s', channel)
+    })
 
-  server.on('publish', function (channel, message) {
-    console.log('broadcast: %s (%d)', channel, message.length)
-  })
+    server.on('publish', function (channel, message) {
+      console.log('broadcast: %s (%d)', channel, message.length)
+    })
+  }
 
   server.listen(argv.port, argv.host, function () {
     console.log('signalhub listening on port %d', server.address().port)
@@ -51,7 +54,9 @@ if (cmd === 'subscribe') {
   if (argv._.length < 3) return console.error('Usage: signalhub subscribe [app] [channel]')
   var client = require('./')(argv._[1], argv.host + ':' + argv.port || 'localhost:8080')
   client.subscribe(argv._[2]).on('data', function (data) {
-    console.log(data)
+    if (!argv.quiet) {
+      console.log(data)
+    }
   })
   return
 }

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "signalhub",
-  "version": "4.3.1",
+  "version": "4.4.1",
   "description": "Simple signalling server that can be used to coordinate handshaking with webrtc or other fun stuff.",
   "main": "index.js",
   "dependencies": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "signalhub",
-  "version": "4.4.1",
+  "version": "4.3.1",
   "description": "Simple signalling server that can be used to coordinate handshaking with webrtc or other fun stuff.",
   "main": "index.js",
   "dependencies": {


### PR DESCRIPTION
It simply adds an option to only log the listening addres:port, avoiding logs for subscribe/broadcast events.