### PR TITLE
Adds heroku support with one-click deployment

### DIFF
--- a/Procfile
+++ b/Procfile
@@ -1,0 +1,1 @@
+web: node ./bin.js listen -p $PORT 

--- a/README.md
+++ b/README.md
@@ -22,12 +22,12 @@ var hub = signalhub('my-app-name', [
   'http://yourhub.com'
 ])
 
-hub.subscribe('/my-channel')
+hub.subscribe('my-channel')
   .on('data', function (message) {
     console.log('new message received', message)
   })
 
-hub.broadcast('/my-channel', {hello: 'world'})
+hub.broadcast('my-channel', {hello: 'world'})
 ```
 
 ## API
@@ -78,6 +78,9 @@ signalhub subscribe my-app my-channel -p 8080 -h yourhub.com
 ## Browserify
 
 This also works in the browser using browserify :)
+
+## Heroku
+[![Deploy](https://www.herokucdn.com/deploy/button.png)](https://heroku.com/deploy
 
 ## License
 

--- a/README.md
+++ b/README.md
@@ -80,7 +80,7 @@ signalhub subscribe my-app my-channel -p 8080 -h yourhub.com
 This also works in the browser using browserify :)
 
 ## Heroku
-[![Deploy](https://www.herokucdn.com/deploy/button.png)](https://heroku.com/deploy
+[![Deploy](https://www.herokucdn.com/deploy/button.png)](https://heroku.com/deploy)
 
 ## License
 

--- a/app.json
+++ b/app.json
@@ -1,0 +1,5 @@
+{
+	"name": "signalhub",
+	"description": "Simple signalling server that can be used to coordinate handshaking with webrtc or other fun stuff.",
+	"repository": "https://github.com/mafintosh/signalhub"
+}


### PR DESCRIPTION
This PR also removes the prefixed `/` when subscribing/publishing in the readme example as there are no tests to support it

Example URL: https://vast-harbor-70144.herokuapp.com/