### PR TITLE
Easy deployment to now.sh

### DIFF
--- a/README.md
+++ b/README.md
@@ -85,7 +85,17 @@ signalhub subscribe my-app my-channel -p 8080 -h yourhub.com
 
 This also works in the browser using browserify :)
 
-## Heroku
+## Deploying with popular services
+
+No additional configuration is needed.
+
+### now.sh
+
+```
+now mafintosh/signalhub
+```
+
+### Heroku
 [![Deploy](https://www.herokucdn.com/deploy/button.png)](https://heroku.com/deploy)
 
 ## License

--- a/package.json
+++ b/package.json
@@ -21,6 +21,7 @@
     "tape": "^4.0.0"
   },
   "scripts": {
+    "start": "node ./bin.js listen",
     "test": "standard && tape test.js"
   },
   "bin": {

--- a/server.js
+++ b/server.js
@@ -75,6 +75,9 @@ module.exports = function (opts) {
 
     if (req.method === 'GET') {
       res.setHeader('Content-Type', 'text/event-stream; charset=utf-8')
+      res.setHeader('Cache-Control', 'no-cache')
+      // Disable NGINX request buffering
+      res.setHeader('X-Accel-Buffering', 'no')
 
       var app = name.split('/')[0]
       var channelNames = name.slice(app.length + 1)


### PR DESCRIPTION
I've started using [`now`](https://zeit.co/now) by @rauchg lately, and I wanted to be able to deploy a signalhub server with now. To this end, I added an npm start script, and the instructions to the README. Note that the instructions say to run "now mafintosh/signalhub" which won't actually work until this change is merged... what I actually used was "now wmhilton-contrib/signalhub". Check it out live!

~https://signalhub-hzbibrznqa.now.sh/~

https://signalhub-jccqtwhdwc.now.sh